### PR TITLE
Fix tesla site name

### DIFF
--- a/src/main/primary_entry/script/common/ServiceURL.js
+++ b/src/main/primary_entry/script/common/ServiceURL.js
@@ -44,7 +44,7 @@ export default {
     STATIC_CONTENT: window.location.origin + "/static",
 
 
-    TESLA_WEB_PAGE: 'http://www.teslamotors.com/findus/location/supercharger/',
+    TESLA_WEB_PAGE: 'http://www.tesla.com/findus/location/supercharger/',
 
     DEFAULT_DISCUSS_URL: 'https://teslamotorsclub.com/tmc/forums/charging-standards-and-infrastructure.77/'
 


### PR DESCRIPTION
Fixes #40 Tesla site name incorrect since the old one is no longer working.